### PR TITLE
update file_get_contents to work with http

### DIFF
--- a/start_session.php
+++ b/start_session.php
@@ -44,7 +44,7 @@ $sprequests = [
 ];
 
 function start_session($type) {
-    global $sprequests, $protocol;
+    global $sprequests;
 
     if (array_key_exists($type, $sprequests))
         $sessionrequest = $sprequests[$type];
@@ -54,12 +54,12 @@ function start_session($type) {
     $jsonsr = json_encode($sessionrequest);
 
     $api_call = array(
-        $protocol => array(
+        'http' => array(
             'method' => 'POST',
             'header' => "Content-type: application/json\r\n"
-                . "Content-Length: " . strlen($jsonsr) . "\r\n"
-                . (!empty(API_TOKEN) ? "Authorization: " . API_TOKEN . "\r\n" : ""),
-            'content' => $jsonsr
+                        . "Content-Length: " . strlen($jsonsr) . "\r\n"
+                        . "Authorization: " . API_TOKEN . "\r\n",
+            'content' => $jsonsr,
         )
     );
 

--- a/start_session.php
+++ b/start_session.php
@@ -2,7 +2,6 @@
 require_once 'config.php';
 
 date_default_timezone_set('UTC');
-$protocol = explode(':', IRMA_SERVER_URL, 2)[0];
 
 $sprequests = [
     '18plus' => [


### PR DESCRIPTION
The previous way of making the request fails when making req to our actual domain due to file_get_contents being unable to use https over http
Changed it similar to the working script of irma-demos
https://github.com/privacybydesign/irma-demos/blob/master/start_session.php

